### PR TITLE
Add new pad number solution

### DIFF
--- a/collections/number/prefix-an-integer-with-zeros.md
+++ b/collections/number/prefix-an-integer-with-zeros.md
@@ -4,5 +4,8 @@ const prefixWithZeros = (number, length) => (number / Math.pow(10, length)).toFi
 // Or
 const prefixWithZeros = (number, length) => `${Array(length).join('0')}${number}`.slice(-length);
 
+// Or
+const prefixWithZeros = (number, length) => String(number).padStart(length, '0');
+
 // prefixWithZeros(42, 5) === '00042'
 ~~~


### PR DESCRIPTION
Hello,

I found another solution for number padding, I guess is more readable.

I do not know what you want to do whit the 2 others, as the edge cases return different results.

For exemple with number 42124545 and padding 5.
```
const prefixWithZeros = (number, length) => (number / Math.pow(10, length)).toFixed(length).substr(2);
// prefixWithZeros(42124545, 5) === '1.24545'
```
Here basically does not support number exceeding the padding length.

```
const prefixWithZeros = (number, length) => `${Array(length).join('0')}${number}`.slice(-length);
// prefixWithZeros(42124545, 5) === '24545'
```
Here the number is cut to the length padding, starting at right side.

```
const prefixWithZeros = (number, length) => String(number).padStart(length, '0');
// prefixWithZeros(42124545, 5) === '42124545'
```
Here the full number is returned as a string.