### PR TITLE
Generate a unique UUID without an external package

### DIFF
--- a/collections/misc/generate-uuid.md
+++ b/collections/misc/generate-uuid.md
@@ -1,0 +1,3 @@
+~~~ javascript
+const uuid = (a) => a ? (a ^ Math.random() * 16 >> a / 4).toString(16) : ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, uuid);
+~~~


### PR DESCRIPTION
Useful for React map() functions which requires a unique key attribute