### PR TITLE
Fix unnecessary cast

### DIFF
--- a/collections/array/check-if-all-items-in-an-array-are-equal.md
+++ b/collections/array/check-if-all-items-in-an-array-are-equal.md
@@ -2,7 +2,7 @@
 const areEqual = arr => arr.length > 0 && arr.every(item => item === arr[0]);
 
 // Or
-const areEqual = arr => [...new Set(arr)].length === 1;
+const areEqual = arr => new Set(arr).size === 1;
 
 // areEqual([1, 2, 3, 4]) === false
 // areEqual(['hello', 'hello', 'hello']) === true


### PR DESCRIPTION
Set also has a length property, faster to access than spreading the set with ... then re-building an array