### PR TITLE
Feat: number mod

### DIFF
--- a/collections/number/calculate-the-mod-of-collection-index.md
+++ b/collections/number/calculate-the-mod-of-collection-index.md
@@ -1,0 +1,7 @@
+~~~ javascript
+const mod = (a, b) => ((a % b) + b) % b;
+
+// mod(-1, 5) === 4
+// mod(3, 5) === 3
+// mod(6, 5) === 1
+~~~


### PR DESCRIPTION
## Description

Add number mod function in order to return the modded index of array.
This will wrap around an array on the left side (`i < 0`) or right side (`i > length`)

## Example

```js
const items = [ 'a', 'b', 'c' ];
const { length } = items;

for (let i = 0; i < length; i += 1) {
  const previous = items[mod(i - 1, length)]; // 'c'
  const current  = items[mod(i,     length)]; // 'a'
  const next     = items[mod(i + 1, length)]; // 'b'
}
```

