### PR TITLE
Ignore spaces and diacritics in anagram checker

### DIFF
--- a/collections/string/check-if-two-strings-are-anagram.md
+++ b/collections/string/check-if-two-strings-are-anagram.md
@@ -9,5 +9,5 @@ const areAnagrams = (str1, str2) => (alphagram = (word) => word.toLowerCase().sp
 // areAnagrams('listen', 'silent') === true
 // areAnagrams('New York Times', 'monkeys write') === true
 // areAnagrams('forty-five', 'over forty') === true
-// areAnagrams('éclair', 'lacier') === true
+// areAnagrams('pâté', 'tape') === true
 ~~~

--- a/collections/string/check-if-two-strings-are-anagram.md
+++ b/collections/string/check-if-two-strings-are-anagram.md
@@ -3,8 +3,8 @@ const areAnagrams = (str1, str2) => (alphagram = (word) => word.toLowerCase().sp
 
 // OR: (one-liners are good to brag, not always good to maintain)
 // An alphagram is a word rearranged with letters in alphabetical order.
-// const alphagram = (word) => word.toLowerCase().split('').sort().join('').normalize('NFD').replace(/[^\w]/g, ''));
-// const anagrams(str1, str2) => alphagram(str1) == alphagram(str2);
+const alphagram = (word) => word.toLowerCase().split('').sort().join('').normalize('NFD').replace(/[^\w]/g, ''));
+const anagrams(str1, str2) => alphagram(str1) == alphagram(str2);
 
 // areAnagrams('listen', 'silent') === true
 // areAnagrams('New York Times', 'monkeys write') === true

--- a/collections/string/check-if-two-strings-are-anagram.md
+++ b/collections/string/check-if-two-strings-are-anagram.md
@@ -9,4 +9,5 @@ const areAnagrams = (str1, str2) => (alphagram = (word) => word.toLowerCase().sp
 // areAnagrams('listen', 'silent') === true
 // areAnagrams('New York Times', 'monkeys write') === true
 // areAnagrams('forty-five', 'over forty') === true
+// areAnagrams('éclair', 'lacier') === true
 ~~~

--- a/collections/string/check-if-two-strings-are-anagram.md
+++ b/collections/string/check-if-two-strings-are-anagram.md
@@ -1,6 +1,12 @@
 ~~~ javascript
-const areAnagram = (str1, str2) => str1.toLowerCase().split('').sort().join('') === str2.toLowerCase().split('').sort().join('');
+const areAnagrams = (str1, str2) => (alphagram = (word) => word.toLowerCase().split('').sort().join('').normalize('NFD').replace(/[^\w]/g, '')) && alphagram(str1) == alphagram(str2);
 
-// areAnagram('listen', 'silent') === true
-// areAnagram('they see', 'the eyes') === true
+// OR: (one-liners are good to brag, not always good to maintain)
+// An alphagram is a word rearranged with letters in alphabetical order.
+// const alphagram = (word) => word.toLowerCase().split('').sort().join('').normalize('NFD').replace(/[^\w]/g, ''));
+// const anagrams(str1, str2) => alphagram(str1) == alphagram(str2);
+
+// areAnagrams('listen', 'silent') === true
+// areAnagrams('New York Times', 'monkeys write') === true
+// areAnagrams('forty-five', 'over forty') === true
 ~~~

--- a/collections/string/check-if-two-strings-are-anagram.md
+++ b/collections/string/check-if-two-strings-are-anagram.md
@@ -3,8 +3,8 @@ const areAnagrams = (str1, str2) => (alphagram = (word) => word.toLowerCase().sp
 
 // OR: (one-liners are good to brag, not always good to maintain)
 // An alphagram is a word rearranged with letters in alphabetical order.
-const alphagram = (word) => word.toLowerCase().split('').sort().join('').normalize('NFD').replace(/[^\w]/g, ''));
-const anagrams(str1, str2) => alphagram(str1) == alphagram(str2);
+const alphagram = (word) => word.toLowerCase().split('').sort().join('').normalize('NFD').replace(/[^\w]/g, '');
+const anagrams = (str1, str2) => alphagram(str1) == alphagram(str2);
 
 // areAnagrams('listen', 'silent') === true
 // areAnagrams('New York Times', 'monkeys write') === true


### PR DESCRIPTION
Improve function to ignore spaces ("New York Times" = "monkeys write"), dashes ("Church of Scientology" = "rich-chosen goofy cult") and special characters in general, including diacritics ("éclair = lacier").

Ignoring diacritics makes function work for all languages written with Latin script.

Add an alternative way to write the one-liner as two lines, as it avoids (a) repetition in the logic and (b) writing two functions in the same line.