### PR TITLE
Updated array-is-not-empty to handle negative indices array

### DIFF
--- a/collections/array/check-if-an-array-is-not-empty.md
+++ b/collections/array/check-if-an-array-is-not-empty.md
@@ -1,5 +1,5 @@
 ~~~ javascript
-const isNotEmpty = arr => Array.isArray(arr) && arr.length > 0;
+const isNotEmpty = arr => Array.isArray(arr) && Object.keys(arr).length > 0;
 
 // isNotEmpty([]) === false
 // isNotEmpty([1, 2, 3]) === true


### PR DESCRIPTION
For an array, `.length` will only consider positive integer indices. So an array declared as 
`const x = [-1: 'a', -2: 'b']` will also have length 0. To overcome this, we can use the fact that arrays are also objects and check if they have any keys. 