### PR TITLE
Use Reflect.ownKeys instead of Object.keys

### DIFF
--- a/collections/object/check-if-an-object-is-empty.md
+++ b/collections/object/check-if-an-object-is-empty.md
@@ -1,6 +1,6 @@
 ~~~ javascript
-const isEmpty = obj => Object.keys(obj).length === 0 && obj.constructor === Object;
+const isEmpty = obj => Reflect.ownKeys(obj).length === 0 && obj.constructor === Object;
 
-// Or
+// Or for enumerable property names only
 const isEmpty = obj => JSON.stringify(obj) === '{}';
 ~~~


### PR DESCRIPTION
`Object.keys` (as well as `JSON.stringify`) only looks at enumerable property names, missing symbol properties and non-enumerable properties (names or symbols).

`Reflect.ownKeys` solves this problem and since it's part of ES6, it has the same support.