### PR TITLE
Remove the option that doesn't actually create a function

### DIFF
--- a/collections/function/create-an-empty-function.md
+++ b/collections/function/create-an-empty-function.md
@@ -2,5 +2,6 @@
 const noop = () => {};
 
 // Or
-const noop = Function.prototype;
+const noop = Function();
+// calling Function() might be detected as using eval by some security tools
 ~~~


### PR DESCRIPTION
Taking the reference is not creating a function. 

> const a = Function.prototype
> const b = Function.prototype
> a===b
true

It can trip up a lot of people, especially when using React or anything that detects changes by strict equal.

> const f = Function()
> const g = Function()
> f === g
false