### PR TITLE
Remove wrong algorithm

### DIFF
--- a/collections/array/compare-two-arrays-regardless-of-order.md
+++ b/collections/array/compare-two-arrays-regardless-of-order.md
@@ -2,9 +2,6 @@
 // `a` and `b` are arrays
 const isEqual = (a, b) => JSON.stringify(a.sort()) === JSON.stringify(b.sort());
 
-// Or
-const isEqual = (a, b) => a.length === b.length && (new Set(a.concat(b)).size === a.length);
-
 // Examples
 isEqual([1, 2, 3], [1, 2, 3]);      // true
 isEqual([1, 2, 3], [1, 3, 2]);      // true


### PR DESCRIPTION
isEqual([1, 2, 2], [1, 2, 2]) will return False, it should be True
isEqual([1, 2, 3], [1, 2, 2]) will return True, it should be False