### PR TITLE
generalise getIntersection, fixes #169

### DIFF
--- a/collections/array/get-the-intersection-of-arrays.md
+++ b/collections/array/get-the-intersection-of-arrays.md
@@ -1,11 +1,5 @@
 ~~~ javascript
-// space: O(n)
-// time: O(n)
-const getIntersection = (...arr) => [...(arr.flat().reduce((map, v) => map.set(v, (map.get(v) || 0) + 1), new Map()))].reduce((acc, [v, count]) => void (count === arr.length && acc.push(v)) || acc, []);
-
-// Or
-// Only support two arrays
-const getIntersection = (a, b) => [...new Set(a)].filter(v => b.includes(v));
+const getIntersection = (a, ...arr) => [...new Set(a)].filter(v => arr.every(b => b.includes(v)));
 
 // Examples
 getIntersection([1, 2, 3], [2, 3, 4, 5]);               // [2, 3]


### PR DESCRIPTION
Generalise the version for two arrays with a version for an unlimited number of arrays.

This removes the time and space optimised version that was, in fact, wrong (see #169)