### PR TITLE
Fix content not fitting on screen in mobile view

### DIFF
--- a/styles/pages/_snippet.scss
+++ b/styles/pages/_snippet.scss
@@ -2,6 +2,12 @@
     display: flex;
 }
 
+@media screen and (max-width: 480px) {
+  .page-snippet__container {
+    flex-direction: column;
+  }
+}
+
 .page-snippet__sidebar {
     flex: 0 0 15rem;
     margin-right: 1rem;


### PR DESCRIPTION
On mobile devices, the content did not fit the screen completely. I added a small line of code to fix this.

**BEFORE:**
<a href="https://ibb.co/1nzdRPV"><img src="https://i.ibb.co/xsFfzBv/Screen-Shot-2022-03-01-at-12-50-03.png" alt="Screen-Shot-2022-03-01-at-12-50-03" border="0"></a>

**AFTER:**
<a href="https://ibb.co/3FcyZw5"><img src="https://i.ibb.co/wQ4NmTZ/Screen-Shot-2022-03-01-at-12-50-13.png" alt="Screen-Shot-2022-03-01-at-12-50-13" border="0"></a>