### PR TITLE
add: new structuredClone method

### DIFF
--- a/snippets/array/clone-an-array.md
+++ b/snippets/array/clone-an-array.md
@@ -23,6 +23,9 @@ const clone = (arr) => JSON.parse(JSON.stringify(arr));
 
 // Or
 const clone = (arr) => arr.concat([]);
+
+// Or
+const clone = (arr) => structuredClone(arr);
 ```
 
 **TypeScript version**
@@ -45,4 +48,7 @@ const clone = <T,_>(arr: T[]): T[] => JSON.parse(JSON.stringify(arr));
 
 // Or
 const clone = <T,_>(arr: T[]): T[] => arr.concat([]);
+
+// Or
+const clone = <T,_>(arr: T[]): T[] => structuredClone(arr);
 ```


### PR DESCRIPTION
new structuredClone method has been added (https://developer.mozilla.org/en-US/docs/Web/API/structuredClone)

JS Version:
```
const clone = (arr) => structuredClone(arr);
```

TS Version:
```
const clone = <T,_>(arr: T[]): T[] => structuredClone(arr);
```