### PR TITLE
fix: Modify the return type to string

### DIFF
--- a/contents/random/generate-a-random-ip-address.md
+++ b/contents/random/generate-a-random-ip-address.md
@@ -17,7 +17,7 @@ const randomIp = () =>
 **TypeScript version**
 
 ```js
-const randomIp = (): number =>
+const randomIp = (): string =>
     Array(4)
         .fill(0)
         .map((_, i) => Math.floor(Math.random() * 255) + (i === 0 ? 1 : 0))


### PR DESCRIPTION
The return value of randomId should be string instead of number, otherwise TS will report an error.